### PR TITLE
Support delayed mirroring with configurable package age

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,10 @@ Promote.NuGet (CLI)                   ← Spectre.Console.Cli commands, entry po
 - **Shared helpers** (`Promote.NuGet.TestInfrastructure`): `LocalNugetFeed`, `ProcessWrapper`, `TempFile`
 - All tests have `[CancelAfter(60_000)]`
 
+### Packages & tools
+
+- **Time testing**: `Microsoft.Extensions.TimeProvider.Testing` package provides `FakeTimeProvider`. The using is `Microsoft.Extensions.Time.Testing` (note: different from package name).
+
 ### Conventions
 
 - **Class names:** `{ClassName}Tests`.
@@ -150,3 +154,9 @@ Package versions go only in `Directory.Packages.props` (central management, tran
 - Never manually edit versions in `Directory.Packages.props` — use `dotnet package add` / `dotnet package update`
 - Never guess versions from memory — always verify with `dotnet package search --exact-match`
 - `dotnet package update` reformats `Directory.Packages.props` (changes indentation). After running it, revert formatting with `git checkout -- Directory.Packages.props` and apply only the version change manually.
+
+## NuGet SDK Pitfalls
+
+- `VersionRange.FindBestMatch(versions)` picks the **lowest** satisfying version (NuGet's minimum version strategy), not the highest. Don't assume it returns the greatest match.
+- `IPackageSearchMetadata.Published` returns `DateTimeOffset?` — available on metadata already fetched via `GetPackageMetadata()`.
+- **Namespace collision**: In test files under `Promote.NuGet.*` namespaces, `NuGet.Packaging` resolves to `Promote.NuGet.Packaging`. Use `global::NuGet.Packaging`, `global::NuGet.Frameworks`, etc.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="2.2.1" />

--- a/README.md
+++ b/README.md
@@ -149,6 +149,26 @@ promote-nuget promote from-config packages.yml --destination '<TARGET-NUGET-FEED
 ```
 
 
+#### Delayed mirroring
+
+You can configure a minimum release age (in days) to avoid mirroring packages that were published too recently.
+This only affects non-exact versions (`latest` and version ranges). Exact versions always bypass this check.
+
+```yaml
+minimum-release-age: 7
+
+packages:
+  - id: System.Text.Json
+    versions: latest
+  - id: Newtonsoft.Json
+    versions: 13.0.3  # exact version, not affected by minimum-release-age
+```
+
+When set, packages published fewer than 7 days ago will be skipped. For dependencies, the resolver will select
+the best matching version that meets the age requirement. If no suitable version exists, mirroring will fail.
+
+If the feed does not provide a publish date for a package, mirroring will fail with an error.
+
 ## Help
 You can use `--help` argument to find all available commands and options. Example:
 

--- a/src/Promote.NuGet.Commands/Promote/PromotePackageCommand.cs
+++ b/src/Promote.NuGet.Commands/Promote/PromotePackageCommand.cs
@@ -1,9 +1,8 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
 using NuGet.Packaging.Core;
 using Promote.NuGet.Commands.Licensing;
 using Promote.NuGet.Commands.Mirroring;
 using Promote.NuGet.Commands.Promote.Resolution;
-using Promote.NuGet.Commands.Requests;
 using Promote.NuGet.Commands.Requests.Resolution;
 using Promote.NuGet.Feeds;
 
@@ -11,23 +10,26 @@ namespace Promote.NuGet.Commands.Promote;
 
 public class PromotePackageCommand
 {
-    private readonly PackageRequestResolver _sourcePackageRequestResolver;
-    private readonly PackagesToPromoteResolver _packagesToPromoteResolver;
+    private readonly INuGetRepository _sourceRepository;
+    private readonly INuGetRepository _destinationRepository;
     private readonly LicenseComplianceValidator _licenseComplianceValidator;
     private readonly PackageMirroringExecutor _packageMirroringExecutor;
     private readonly IPromotePackageLogger _promotePackageLogger;
+    private readonly TimeProvider _timeProvider;
 
     public PromotePackageCommand(INuGetRepository sourceRepository,
                                  INuGetRepository destinationRepository,
-                                 IPromotePackageLogger promotePackageLogger)
+                                 IPromotePackageLogger promotePackageLogger,
+                                 TimeProvider timeProvider)
     {
         if (sourceRepository == null) throw new ArgumentNullException(nameof(sourceRepository));
         if (destinationRepository == null) throw new ArgumentNullException(nameof(destinationRepository));
         if (promotePackageLogger == null) throw new ArgumentNullException(nameof(promotePackageLogger));
 
+        _sourceRepository = sourceRepository;
+        _destinationRepository = destinationRepository;
         _promotePackageLogger = promotePackageLogger;
-        _sourcePackageRequestResolver = new PackageRequestResolver(sourceRepository, promotePackageLogger);
-        _packagesToPromoteResolver = new PackagesToPromoteResolver(sourceRepository, destinationRepository, promotePackageLogger);
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         _packageMirroringExecutor = new PackageMirroringExecutor(sourceRepository, destinationRepository, promotePackageLogger);
         _licenseComplianceValidator = new LicenseComplianceValidator(sourceRepository, promotePackageLogger);
     }
@@ -39,8 +41,10 @@ public class PromotePackageCommand
         if (arguments == null) throw new ArgumentNullException(nameof(arguments));
         if (options == null) throw new ArgumentNullException(nameof(options));
 
+        var sourcePackageRequestResolver = new PackageRequestResolver(_sourceRepository, _promotePackageLogger, arguments.MinimumReleaseAge, _timeProvider);
+
         var requests = arguments.Requests;
-        var resolvePackagesResult = await _sourcePackageRequestResolver.ResolvePackageRequests(requests, cancellationToken);
+        var resolvePackagesResult = await sourcePackageRequestResolver.ResolvePackageRequests(requests, cancellationToken);
         if (resolvePackagesResult.IsFailure)
         {
             return Result.Failure(resolvePackagesResult.Error);
@@ -53,7 +57,7 @@ public class PromotePackageCommand
             return Result.Success();
         }
 
-        var packagesToPromoteResult = await ResolvePackagesToPromote(identities, options, cancellationToken);
+        var packagesToPromoteResult = await ResolvePackagesToPromote(identities, arguments.MinimumReleaseAge, options, cancellationToken);
         if (packagesToPromoteResult.IsFailure)
         {
             return Result.Failure(packagesToPromoteResult.Error);
@@ -82,10 +86,13 @@ public class PromotePackageCommand
     }
 
     private async Task<Result<IReadOnlyCollection<PackageInfo>>> ResolvePackagesToPromote(IReadOnlySet<PackageIdentity> identities,
+                                                                                          TimeSpan? minimumReleaseAge,
                                                                                           PromotePackageCommandOptions options,
                                                                                           CancellationToken cancellationToken)
     {
-        var packageTreeResult = await _packagesToPromoteResolver.ResolvePackageTree(identities, options, cancellationToken);
+        var packagesToPromoteResolver = new PackagesToPromoteResolver(_sourceRepository, _destinationRepository, _promotePackageLogger, minimumReleaseAge, _timeProvider);
+
+        var packageTreeResult = await packagesToPromoteResolver.ResolvePackageTree(identities, options, cancellationToken);
         if (packageTreeResult.IsFailure)
         {
             return Result.Failure<IReadOnlyCollection<PackageInfo>>(packageTreeResult.Error);

--- a/src/Promote.NuGet.Commands/Promote/PromotePackageCommandArguments.cs
+++ b/src/Promote.NuGet.Commands/Promote/PromotePackageCommandArguments.cs
@@ -5,5 +5,6 @@ namespace Promote.NuGet.Commands.Promote;
 
 public record PromotePackageCommandArguments(
     IReadOnlyCollection<PackageRequest> Requests,
-    LicenseComplianceSettings LicenseComplianceSettings
+    LicenseComplianceSettings LicenseComplianceSettings,
+    TimeSpan? MinimumReleaseAge = null
 );

--- a/src/Promote.NuGet.Commands/Promote/Resolution/IPackagesToPromoteResolverLogger.cs
+++ b/src/Promote.NuGet.Commands/Promote/Resolution/IPackagesToPromoteResolverLogger.cs
@@ -1,4 +1,5 @@
 ﻿using NuGet.Packaging.Core;
+using NuGet.Versioning;
 using Promote.NuGet.Commands.Licensing;
 
 namespace Promote.NuGet.Commands.Promote.Resolution;
@@ -24,4 +25,8 @@ public interface IPackagesToPromoteResolverLogger
     void LogPackageDependenciesSkipped(PackageIdentity identity);
 
     void LogResolvedPackageTree(PackageResolutionTree packageTree);
+
+    void LogDependencyVersionSkippedDueToAge(PackageIdentity source, string dependencyId, NuGetVersion version, DateTimeOffset publishedDate);
+
+    void LogDependencyResolvedToOlderVersionDueToAge(PackageIdentity source, string dependencyId, NuGetVersion bestVersion, NuGetVersion selectedVersion);
 }

--- a/src/Promote.NuGet.Commands/Promote/Resolution/PackagesToPromoteResolver.cs
+++ b/src/Promote.NuGet.Commands/Promote/Resolution/PackagesToPromoteResolver.cs
@@ -1,6 +1,7 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 using Promote.NuGet.Commands.Core;
 using Promote.NuGet.Commands.Licensing;
 using Promote.NuGet.Feeds;
@@ -12,14 +13,20 @@ public class PackagesToPromoteResolver
     private readonly INuGetRepository _sourceRepository;
     private readonly INuGetRepository _destinationRepository;
     private readonly IPackagesToPromoteResolverLogger _logger;
+    private readonly TimeSpan? _minimumReleaseAge;
+    private readonly TimeProvider _timeProvider;
 
     public PackagesToPromoteResolver(INuGetRepository sourceRepository,
                                      INuGetRepository destinationRepository,
-                                     IPackagesToPromoteResolverLogger logger)
+                                     IPackagesToPromoteResolverLogger logger,
+                                     TimeSpan? minimumReleaseAge,
+                                     TimeProvider timeProvider)
     {
         _sourceRepository = sourceRepository ?? throw new ArgumentNullException(nameof(sourceRepository));
         _destinationRepository = destinationRepository ?? throw new ArgumentNullException(nameof(destinationRepository));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _minimumReleaseAge = minimumReleaseAge;
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
     public async Task<Result<PackageResolutionTree>> ResolvePackageTree(IReadOnlySet<PackageIdentity> identities,
@@ -167,7 +174,87 @@ public class PackagesToPromoteResolver
             return Result.Failure<PackageIdentity>(allVersionsOfDepResult.Error);
         }
 
-        var bestMatchVersion = dependencyVersionRange.FindBestMatch(allVersionsOfDepResult.Value);
+        var allVersions = allVersionsOfDepResult.Value;
+        var bestMatchVersion = dependencyVersionRange.FindBestMatch(allVersions);
+
+        if (_minimumReleaseAge is not { } minimumAge)
+        {
+            return await EnqueueResolvedDependency(context, source, dependencyId, bestMatchVersion);
+        }
+
+        var filteredVersionsResult = await FilterVersionsByAge(context, source, dependencyId, dependencyVersionRange, allVersions, minimumAge, cancellationToken);
+        if (filteredVersionsResult.IsFailure)
+        {
+            return Result.Failure<PackageIdentity>(filteredVersionsResult.Error);
+        }
+
+        var filteredVersions = filteredVersionsResult.Value;
+        var filteredBestMatch = dependencyVersionRange.FindBestMatch(filteredVersions);
+
+        if (filteredBestMatch is null)
+        {
+            return Result.Failure<PackageIdentity>(
+                $"Dependency {dependencyId} of {source.Id} {source.Version} has no version satisfying {dependencyVersionRange.PrettyPrint()} that meets the minimum release age.");
+        }
+
+        if (bestMatchVersion is not null && filteredBestMatch != bestMatchVersion)
+        {
+            _logger.LogDependencyResolvedToOlderVersionDueToAge(source, dependencyId, bestMatchVersion, filteredBestMatch);
+        }
+
+        return await EnqueueResolvedDependency(context, source, dependencyId, filteredBestMatch);
+    }
+
+    private async Task<Result<IReadOnlyCollection<NuGetVersion>>> FilterVersionsByAge(
+        ResolutionContext context,
+        PackageIdentity source,
+        string dependencyId,
+        VersionRange dependencyVersionRange,
+        IReadOnlyCollection<NuGetVersion> allVersions,
+        TimeSpan minimumAge,
+        CancellationToken cancellationToken)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var filtered = new List<NuGetVersion>();
+
+        foreach (var version in allVersions)
+        {
+            if (!dependencyVersionRange.Satisfies(version))
+            {
+                continue;
+            }
+
+            var identity = new PackageIdentity(dependencyId, version);
+            var metadataResult = await _sourceRepository.Packages.GetPackageMetadata(identity, cancellationToken);
+            if (metadataResult.IsFailure)
+            {
+                return Result.Failure<IReadOnlyCollection<NuGetVersion>>(metadataResult.Error);
+            }
+
+            var published = metadataResult.Value.Published;
+            if (published is null)
+            {
+                return Result.Failure<IReadOnlyCollection<NuGetVersion>>(
+                    $"Package {dependencyId} {version} has no publish date. Cannot apply minimum release age filter.");
+            }
+
+            if ((now - published.Value) < minimumAge)
+            {
+                _logger.LogDependencyVersionSkippedDueToAge(source, dependencyId, version, published.Value);
+                continue;
+            }
+
+            filtered.Add(version);
+        }
+
+        return filtered;
+    }
+
+    private async Task<Result<PackageIdentity>> EnqueueResolvedDependency(ResolutionContext context,
+                                                                          PackageIdentity source,
+                                                                          string dependencyId,
+                                                                          NuGetVersion? bestMatchVersion)
+    {
         var resolvedPackage = new PackageIdentity(dependencyId, bestMatchVersion);
 
         var enqueued = context.PackagesToResolveQueue.Enqueue(resolvedPackage);

--- a/src/Promote.NuGet.Commands/Requests/Resolution/IPackageRequestResolverLogger.cs
+++ b/src/Promote.NuGet.Commands/Requests/Resolution/IPackageRequestResolverLogger.cs
@@ -1,4 +1,5 @@
 ﻿using NuGet.Packaging.Core;
+using NuGet.Versioning;
 
 namespace Promote.NuGet.Commands.Requests.Resolution;
 
@@ -9,4 +10,6 @@ public interface IPackageRequestResolverLogger
     void LogResolvingPackageRequest(PackageRequest request);
 
     void LogPackageRequestResolution(PackageRequest request, IReadOnlyCollection<PackageIdentity> matchingPackages);
+
+    void LogPackageVersionSkippedDueToAge(string packageId, NuGetVersion version, DateTimeOffset publishedDate);
 }

--- a/src/Promote.NuGet.Commands/Requests/Resolution/PackageRequestResolver.cs
+++ b/src/Promote.NuGet.Commands/Requests/Resolution/PackageRequestResolver.cs
@@ -1,4 +1,4 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
 using NuGet.Packaging.Core;
 using Promote.NuGet.Feeds;
 
@@ -8,11 +8,18 @@ public sealed class PackageRequestResolver
 {
     private readonly INuGetRepository _repository;
     private readonly IPackageRequestResolverLogger _logger;
+    private readonly TimeSpan? _minimumReleaseAge;
+    private readonly TimeProvider _timeProvider;
 
-    public PackageRequestResolver(INuGetRepository repository, IPackageRequestResolverLogger logger)
+    public PackageRequestResolver(INuGetRepository repository,
+                                  IPackageRequestResolverLogger logger,
+                                  TimeSpan? minimumReleaseAge,
+                                  TimeProvider timeProvider)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _logger = logger;
+        _minimumReleaseAge = minimumReleaseAge;
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
     public async Task<Result<IReadOnlySet<PackageIdentity>>> ResolvePackageRequests(
@@ -30,7 +37,7 @@ public sealed class PackageRequestResolver
 
             _logger.LogResolvingPackageRequest(request);
 
-            var visitor = new ResolvePackageVersionPolicyVisitor(request.Id, _repository);
+            var visitor = new ResolvePackageVersionPolicyVisitor(request.Id, _repository, _logger, _minimumReleaseAge, _timeProvider);
 
             foreach (var versionRequest in request.VersionPolicies)
             {

--- a/src/Promote.NuGet.Commands/Requests/Resolution/ResolvePackageVersionPolicyVisitor.cs
+++ b/src/Promote.NuGet.Commands/Requests/Resolution/ResolvePackageVersionPolicyVisitor.cs
@@ -1,5 +1,6 @@
 using CSharpFunctionalExtensions;
 using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
 using Promote.NuGet.Feeds;
 
 namespace Promote.NuGet.Commands.Requests.Resolution;
@@ -8,11 +9,21 @@ internal sealed class ResolvePackageVersionPolicyVisitor : IPackageVersionPolicy
 {
     private readonly string _packageId;
     private readonly INuGetRepository _repository;
+    private readonly IPackageRequestResolverLogger _logger;
+    private readonly TimeSpan? _minimumReleaseAge;
+    private readonly TimeProvider _timeProvider;
 
-    public ResolvePackageVersionPolicyVisitor(string packageId, INuGetRepository repository)
+    public ResolvePackageVersionPolicyVisitor(string packageId,
+                                              INuGetRepository repository,
+                                              IPackageRequestResolverLogger logger,
+                                              TimeSpan? minimumReleaseAge,
+                                              TimeProvider timeProvider)
     {
         _packageId = packageId ?? throw new ArgumentNullException(nameof(packageId));
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _minimumReleaseAge = minimumReleaseAge;
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
     public async Task<Result<IReadOnlySet<PackageIdentity>>> Visit(ExactPackageVersionPolicy versionPolicy, CancellationToken cancellationToken = default)
@@ -67,6 +78,17 @@ internal sealed class ResolvePackageVersionPolicyVisitor : IPackageVersionPolicy
                 continue;
             }
 
+            var ageCheckResult = CheckReleaseAge(packageMetadata.Value);
+            if (ageCheckResult.IsFailure)
+            {
+                return Result.Failure<IReadOnlySet<PackageIdentity>>(ageCheckResult.Error);
+            }
+
+            if (!ageCheckResult.Value)
+            {
+                continue;
+            }
+
             matchingPackages.Add(packageIdentity);
         }
 
@@ -98,9 +120,49 @@ internal sealed class ResolvePackageVersionPolicyVisitor : IPackageVersionPolicy
                 continue;
             }
 
+            var ageCheckResult = CheckReleaseAge(packageMetadata.Value);
+            if (ageCheckResult.IsFailure)
+            {
+                return Result.Failure<IReadOnlySet<PackageIdentity>>(ageCheckResult.Error);
+            }
+
+            if (!ageCheckResult.Value)
+            {
+                continue;
+            }
+
             return new HashSet<PackageIdentity>(capacity: 1) { identity };
         }
 
         return Result.Failure<IReadOnlySet<PackageIdentity>>($"Package {_packageId} has no released versions");
+    }
+
+    /// <summary>
+    /// Checks whether the package meets the minimum release age requirement.
+    /// Returns <c>Result.Success(true)</c> if old enough or no filter is set,
+    /// <c>Result.Success(false)</c> if too new (and logs the skip),
+    /// or <c>Result.Failure</c> if the published date is missing.
+    /// </summary>
+    private Result<bool> CheckReleaseAge(IPackageSearchMetadata metadata)
+    {
+        if (_minimumReleaseAge is not { } minimumAge)
+        {
+            return true;
+        }
+
+        var published = metadata.Published;
+        if (published is null)
+        {
+            return Result.Failure<bool>($"Package {_packageId} {metadata.Identity.Version} has no publish date. Cannot apply minimum release age filter.");
+        }
+
+        var age = _timeProvider.GetUtcNow() - published.Value;
+        if (age < minimumAge)
+        {
+            _logger.LogPackageVersionSkippedDueToAge(_packageId, metadata.Identity.Version, published.Value);
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Promote.NuGet/Promote/FromConfiguration/PromoteConfiguration.cs
+++ b/src/Promote.NuGet/Promote/FromConfiguration/PromoteConfiguration.cs
@@ -4,6 +4,8 @@ namespace Promote.NuGet.Promote.FromConfiguration;
 
 public class PromoteConfiguration
 {
+    public int? MinimumReleaseAge { get; init; }
+
     public LicenseComplianceCheckConfiguration? LicenseComplianceCheck { get; init; }
 
     public PackageConfiguration[] Packages { get; init; } = default!;
@@ -13,6 +15,7 @@ public class PackagesConfigurationValidator : AbstractValidator<PromoteConfigura
 {
     public PackagesConfigurationValidator()
     {
+        RuleFor(x => x.MinimumReleaseAge).GreaterThan(0).When(x => x.MinimumReleaseAge.HasValue);
         RuleFor(x => x.LicenseComplianceCheck).SetValidator(new LicenseComplianceCheckConfigurationValidator()!);
         RuleFor(x => x.Packages).NotEmpty().ForEach(x => x.NotNull().SetValidator(new PackageConfigurationValidator()));
     }

--- a/src/Promote.NuGet/Promote/FromConfiguration/PromoteFromConfigurationCommand.cs
+++ b/src/Promote.NuGet/Promote/FromConfiguration/PromoteFromConfigurationCommand.cs
@@ -39,7 +39,7 @@ internal sealed class PromoteFromConfigurationCommand : AsyncCommand<PromoteFrom
         }
 
         var promotePackageLogger = new PromotePackageLogger(verbose: promoteSettings.Verbose);
-        var promoter = new PromotePackageCommand(sourceRepository, destinationRepository, promotePackageLogger);
+        var promoter = new PromotePackageCommand(sourceRepository, destinationRepository, promotePackageLogger, TimeProvider.System);
 
         var options = new PromotePackageCommandOptions(promoteSettings.DryRun, promoteSettings.AlwaysResolveDeps, promoteSettings.ForcePush);
 
@@ -68,9 +68,15 @@ internal sealed class PromoteFromConfigurationCommand : AsyncCommand<PromoteFrom
         var configurationDirectory = Path.GetDirectoryName(file);
         Normalize(parseResult.Value, configurationDirectory);
 
-        var requests = parseResult.Value.Packages.Select(x => new PackageRequest(x.Id, x.Versions)).ToList();
+        var configuration = parseResult.Value;
 
-        var complianceOptions = parseResult.Value.LicenseComplianceCheck;
+        var requests = configuration.Packages.Select(x => new PackageRequest(x.Id, x.Versions)).ToList();
+
+        var minimumReleaseAge = configuration.MinimumReleaseAge.HasValue
+                                    ? TimeSpan.FromDays(configuration.MinimumReleaseAge.Value)
+                                    : (TimeSpan?)null;
+
+        var complianceOptions = configuration.LicenseComplianceCheck;
         var licenseComplianceSettings = complianceOptions != null
                                             ? new LicenseComplianceSettings
                                               {
@@ -82,7 +88,7 @@ internal sealed class PromoteFromConfigurationCommand : AsyncCommand<PromoteFrom
                                               }
                                             : LicenseComplianceSettings.Disabled;
 
-        return new PromotePackageCommandArguments(requests, licenseComplianceSettings);
+        return new PromotePackageCommandArguments(requests, licenseComplianceSettings, minimumReleaseAge);
     }
 
     private static void Normalize(PromoteConfiguration configuration, string? relativePathResolutionRoot)

--- a/src/Promote.NuGet/Promote/List/PromotePackageListCommand.cs
+++ b/src/Promote.NuGet/Promote/List/PromotePackageListCommand.cs
@@ -39,7 +39,7 @@ internal sealed class PromotePackageListCommand : AsyncCommand<PromotePackageLis
         }
 
         var promotePackageLogger = new PromotePackageLogger(verbose: promoteSettings.Verbose);
-        var promoter = new PromotePackageCommand(sourceRepository, destinationRepository, promotePackageLogger);
+        var promoter = new PromotePackageCommand(sourceRepository, destinationRepository, promotePackageLogger, TimeProvider.System);
 
         var arguments = new PromotePackageCommandArguments(identitiesResult.Value, LicenseComplianceSettings.Disabled);
         var options = new PromotePackageCommandOptions(promoteSettings.DryRun, promoteSettings.AlwaysResolveDeps, promoteSettings.ForcePush);

--- a/src/Promote.NuGet/Promote/PromotePackageLogger.cs
+++ b/src/Promote.NuGet/Promote/PromotePackageLogger.cs
@@ -1,4 +1,5 @@
 using NuGet.Packaging.Core;
+using NuGet.Versioning;
 using Promote.NuGet.Commands.Licensing;
 using Promote.NuGet.Commands.Mirroring;
 using Promote.NuGet.Commands.Promote;
@@ -52,6 +53,13 @@ public sealed class PromotePackageLogger(bool verbose) : IPromotePackageLogger
             }
             AnsiConsole.Write(tree);
         }
+    }
+
+    void IPackageRequestResolverLogger.LogPackageVersionSkippedDueToAge(string packageId, NuGetVersion version, DateTimeOffset publishedDate)
+    {
+        var text = Markup.FromInterpolated($"[yellow]Skipping {packageId} {version} (published {publishedDate:d}): does not meet minimum release age.[/]");
+        var padder = new Padder(text).Padding(left: SingleLeftPaddingSize, top: 0, right: 0, bottom: 0);
+        AnsiConsole.Write(padder);
     }
 
     void IPackagesToPromoteResolverLogger.LogResolvingPackagesToPromote(IReadOnlyCollection<PackageIdentity> identities)
@@ -208,8 +216,22 @@ public sealed class PromotePackageLogger(bool verbose) : IPromotePackageLogger
 
         foreach (var child in dependencies.OrderBy(x => x))
         {
-            AddNodeAndChildren(node, packageTree, child, expanded, rootLevel: false);
+            AddNodeAndChildren(node, packageTree, child, expanded, false);
         }
+    }
+
+    void IPackagesToPromoteResolverLogger.LogDependencyVersionSkippedDueToAge(PackageIdentity source, string dependencyId, NuGetVersion version, DateTimeOffset publishedDate)
+    {
+        var text = Markup.FromInterpolated($"[yellow]Skipping dependency {dependencyId} {version} (published {publishedDate:d}): does not meet minimum release age.[/]");
+        var padder = new Padder(text).Padding(left: SingleLeftPaddingSize * 2, top: 0, right: 0, bottom: 0);
+        AnsiConsole.Write(padder);
+    }
+
+    void IPackagesToPromoteResolverLogger.LogDependencyResolvedToOlderVersionDueToAge(PackageIdentity source, string dependencyId, NuGetVersion bestVersion, NuGetVersion selectedVersion)
+    {
+        var text = Markup.FromInterpolated($"[yellow]Dependency {dependencyId}: best match {bestVersion} is too new; using {selectedVersion} instead.[/]");
+        var padder = new Padder(text).Padding(left: SingleLeftPaddingSize * 2, top: 0, right: 0, bottom: 0);
+        AnsiConsole.Write(padder);
     }
 
     void IPromotePackageLogger.LogPackagesToPromote(IReadOnlyCollection<PackageInfo> packages)
@@ -354,7 +376,6 @@ public sealed class PromotePackageLogger(bool verbose) : IPromotePackageLogger
         var text = Markup.FromInterpolated($"[red]Failed to read accepted file {acceptedFilePath}: {exception.Message}[/]");
         var padder = new Padder(text).Padding(left: SingleLeftPaddingSize, top: 0, right: 0, bottom: 0);
         AnsiConsole.Write(padder);
-
     }
 
     private static string Decl(int count, string one, string many)

--- a/src/Promote.NuGet/Promote/SinglePackage/PromoteSinglePackageCommand.cs
+++ b/src/Promote.NuGet/Promote/SinglePackage/PromoteSinglePackageCommand.cs
@@ -33,7 +33,7 @@ internal sealed class PromoteSinglePackageCommand : AsyncCommand<PromoteSinglePa
         var packageRequest = CreatePackageRequest(promoteSettings);
 
         var promotePackageLogger = new PromotePackageLogger(verbose: promoteSettings.Verbose);
-        var promoter = new PromotePackageCommand(sourceRepository, destinationRepository, promotePackageLogger);
+        var promoter = new PromotePackageCommand(sourceRepository, destinationRepository, promotePackageLogger, TimeProvider.System);
 
         var arguments = new PromotePackageCommandArguments([packageRequest], LicenseComplianceSettings.Disabled);
         var options = new PromotePackageCommandOptions(promoteSettings.DryRun, promoteSettings.AlwaysResolveDeps, promoteSettings.ForcePush);

--- a/tests/Promote.NuGet.Commands.Tests/Promote.NuGet.Commands.Tests.csproj
+++ b/tests/Promote.NuGet.Commands.Tests/Promote.NuGet.Commands.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="NuGet.Protocol" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Promote.NuGet.Commands.Tests/Promote/Resolution/PackagesToPromoteResolverReleaseAgeTests.cs
+++ b/tests/Promote.NuGet.Commands.Tests/Promote/Resolution/PackagesToPromoteResolverReleaseAgeTests.cs
@@ -1,0 +1,191 @@
+using CSharpFunctionalExtensions;
+using Microsoft.Extensions.Time.Testing;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using Promote.NuGet.Commands.Promote;
+using Promote.NuGet.Commands.Promote.Resolution;
+using Promote.NuGet.Feeds;
+
+namespace Promote.NuGet.Commands.Tests.Promote.Resolution;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+public class PackagesToPromoteResolverReleaseAgeTests
+{
+    private static readonly DateTimeOffset Now = new(2025, 6, 15, 0, 0, 0, TimeSpan.Zero);
+
+    [Test, CancelAfter(60_000)]
+    public async Task Dependency_selects_different_version_when_best_match_is_too_new()
+    {
+        // FindBestMatch picks the lowest satisfying version (1.0.0).
+        // 1.0.0 is too new → filtered out → falls back to 2.0.0 which is old enough.
+        var rootId = new PackageIdentity("Root", new NuGetVersion(1, 0, 0));
+        var depId = "Dependency";
+        var depV1 = new NuGetVersion(1, 0, 0);
+        var depV2 = new NuGetVersion(2, 0, 0);
+
+        var sourceRepo = CreateSourceRepository(rootId, depId, [depV1, depV2],
+            v => v == depV1 ? Now - TimeSpan.FromDays(1) : Now - TimeSpan.FromDays(10));
+
+        var destRepo = CreateEmptyDestinationRepository();
+        var logger = Substitute.For<IPackagesToPromoteResolverLogger>();
+        var timeProvider = new FakeTimeProvider(Now);
+
+        var sut = new PackagesToPromoteResolver(sourceRepo, destRepo, logger, TimeSpan.FromDays(7), timeProvider);
+
+        // Act
+        var result = await sut.ResolvePackageTree(
+            new HashSet<PackageIdentity> { rootId },
+            new PromotePackageCommandOptions(dryRun: false, alwaysResolveDeps: false, forcePush: false),
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var depPackages = result.Value.AllPackages.Where(p => p.Id.Id == depId).ToList();
+        depPackages.Should().ContainSingle().Which.Id.Version.Should().Be(depV2);
+
+        logger.Received().LogDependencyResolvedToOlderVersionDueToAge(rootId, depId, depV1, depV2);
+    }
+
+    [Test, CancelAfter(60_000)]
+    public async Task Dependency_fails_when_no_version_meets_age_requirement()
+    {
+        var rootId = new PackageIdentity("Root", new NuGetVersion(1, 0, 0));
+        var depId = "Dependency";
+        var depV1 = new NuGetVersion(1, 0, 0);
+
+        var sourceRepo = CreateSourceRepository(rootId, depId, [depV1],
+            _ => Now - TimeSpan.FromDays(1));
+
+        var destRepo = CreateEmptyDestinationRepository();
+        var logger = Substitute.For<IPackagesToPromoteResolverLogger>();
+        var timeProvider = new FakeTimeProvider(Now);
+
+        var sut = new PackagesToPromoteResolver(sourceRepo, destRepo, logger, TimeSpan.FromDays(7), timeProvider);
+
+        // Act
+        var result = await sut.ResolvePackageTree(
+            new HashSet<PackageIdentity> { rootId },
+            new PromotePackageCommandOptions(dryRun: false, alwaysResolveDeps: false, forcePush: false),
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("no version satisfying");
+    }
+
+    [Test, CancelAfter(60_000)]
+    public async Task Dependency_uses_best_match_when_filter_is_null()
+    {
+        var rootId = new PackageIdentity("Root", new NuGetVersion(1, 0, 0));
+        var depId = "Dependency";
+        var depV1 = new NuGetVersion(1, 0, 0);
+        var depV2 = new NuGetVersion(2, 0, 0);
+
+        var sourceRepo = CreateSourceRepository(rootId, depId, [depV1, depV2],
+            _ => Now - TimeSpan.FromDays(1));
+
+        var destRepo = CreateEmptyDestinationRepository();
+        var logger = Substitute.For<IPackagesToPromoteResolverLogger>();
+
+        var sut = new PackagesToPromoteResolver(sourceRepo, destRepo, logger, minimumReleaseAge: null, TimeProvider.System);
+
+        // Act
+        var result = await sut.ResolvePackageTree(
+            new HashSet<PackageIdentity> { rootId },
+            new PromotePackageCommandOptions(dryRun: false, alwaysResolveDeps: false, forcePush: false),
+            CancellationToken.None);
+
+        // Assert — FindBestMatch picks the lowest satisfying version
+        result.IsSuccess.Should().BeTrue();
+        var depPackages = result.Value.AllPackages.Where(p => p.Id.Id == depId).ToList();
+        depPackages.Should().ContainSingle().Which.Id.Version.Should().Be(depV1);
+    }
+
+    [Test, CancelAfter(60_000)]
+    public async Task Dependency_fails_when_published_date_is_null()
+    {
+        var rootId = new PackageIdentity("Root", new NuGetVersion(1, 0, 0));
+        var depId = "Dependency";
+        var depV1 = new NuGetVersion(1, 0, 0);
+
+        var sourceRepo = CreateSourceRepository(rootId, depId, [depV1], _ => null);
+
+        var destRepo = CreateEmptyDestinationRepository();
+        var logger = Substitute.For<IPackagesToPromoteResolverLogger>();
+        var timeProvider = new FakeTimeProvider(Now);
+
+        var sut = new PackagesToPromoteResolver(sourceRepo, destRepo, logger, TimeSpan.FromDays(7), timeProvider);
+
+        // Act
+        var result = await sut.ResolvePackageTree(
+            new HashSet<PackageIdentity> { rootId },
+            new PromotePackageCommandOptions(dryRun: false, alwaysResolveDeps: false, forcePush: false),
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("no publish date");
+    }
+
+    private static INuGetRepository CreateSourceRepository(
+        PackageIdentity rootId,
+        string depId,
+        NuGetVersion[] depVersions,
+        Func<NuGetVersion, DateTimeOffset?> depPublishedDateProvider)
+    {
+        var accessor = Substitute.For<INuGetPackageInfoAccessor>();
+
+        // Root package metadata with a dependency
+        var rootMetadata = Substitute.For<IPackageSearchMetadata>();
+        rootMetadata.Identity.Returns(rootId);
+        rootMetadata.IsListed.Returns(true);
+        rootMetadata.Published.Returns(Now - TimeSpan.FromDays(30));
+        rootMetadata.LicenseMetadata.Returns((global::NuGet.Packaging.LicenseMetadata?)null);
+        rootMetadata.LicenseUrl.Returns((Uri?)null);
+
+        var depGroup = new global::NuGet.Packaging.PackageDependencyGroup(
+            global::NuGet.Frameworks.NuGetFramework.AnyFramework,
+            [new global::NuGet.Packaging.Core.PackageDependency(depId, VersionRange.Parse("[1.0.0,)"))]);
+        rootMetadata.DependencySets.Returns(new[] { depGroup });
+
+        accessor.GetPackageMetadata(rootId, Arg.Any<CancellationToken>())
+                .Returns(Result.Success(rootMetadata));
+
+        // Dependency versions
+        accessor.GetAllVersions(depId, Arg.Any<CancellationToken>())
+                .Returns(Result.Success<IReadOnlyCollection<NuGetVersion>>(depVersions));
+
+        // Dependency metadata per version
+        foreach (var v in depVersions)
+        {
+            var depIdentity = new PackageIdentity(depId, v);
+            var depMeta = Substitute.For<IPackageSearchMetadata>();
+            depMeta.Identity.Returns(depIdentity);
+            depMeta.IsListed.Returns(true);
+            depMeta.Published.Returns(depPublishedDateProvider(v));
+            depMeta.LicenseMetadata.Returns((global::NuGet.Packaging.LicenseMetadata?)null);
+            depMeta.LicenseUrl.Returns((Uri?)null);
+            depMeta.DependencySets.Returns(Array.Empty<global::NuGet.Packaging.PackageDependencyGroup>());
+
+            accessor.GetPackageMetadata(depIdentity, Arg.Any<CancellationToken>())
+                    .Returns(Result.Success(depMeta));
+        }
+
+        var repo = Substitute.For<INuGetRepository>();
+        repo.Packages.Returns(accessor);
+        return repo;
+    }
+
+    private static INuGetRepository CreateEmptyDestinationRepository()
+    {
+        var accessor = Substitute.For<INuGetPackageInfoAccessor>();
+        accessor.DoesPackageExist(Arg.Any<PackageIdentity>(), Arg.Any<CancellationToken>())
+                .Returns(Result.Success(false));
+
+        var repo = Substitute.For<INuGetRepository>();
+        repo.Packages.Returns(accessor);
+        return repo;
+    }
+}

--- a/tests/Promote.NuGet.Commands.Tests/Requests/Resolution/ResolvePackageVersionPolicyVisitorTests.cs
+++ b/tests/Promote.NuGet.Commands.Tests/Requests/Resolution/ResolvePackageVersionPolicyVisitorTests.cs
@@ -1,7 +1,6 @@
-﻿using CSharpFunctionalExtensions;
-using NuGet.Common;
+using CSharpFunctionalExtensions;
+using Microsoft.Extensions.Time.Testing;
 using NuGet.Packaging.Core;
-using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using Promote.NuGet.Commands.Requests;
@@ -13,7 +12,9 @@ namespace Promote.NuGet.Commands.Tests.Requests.Resolution;
 [TestFixture]
 public class ResolvePackageVersionPolicyVisitorTests
 {
-    [Test]
+    private static readonly DateTimeOffset OldPublishDate = new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    [Test, CancelAfter(60_000)]
     public async Task Visit_LatestPackageRequest_finds_greatest_released_package_version()
     {
         var packageId = "package-id";
@@ -28,7 +29,7 @@ public class ResolvePackageVersionPolicyVisitorTests
 
         var nugetRepository = SetupRepository(packageId, versions);
 
-        var sut = new ResolvePackageVersionPolicyVisitor(packageId, nugetRepository);
+        var sut = CreateVisitor(packageId, nugetRepository);
 
         var latestVersion = await sut.Visit(new LatestPackageVersionPolicy());
 
@@ -36,7 +37,7 @@ public class ResolvePackageVersionPolicyVisitorTests
         latestVersion.Value.Should().BeEquivalentTo(new[] { new PackageIdentity(packageId, new NuGetVersion(1, 0, 1)) });
     }
 
-    [Test]
+    [Test, CancelAfter(60_000)]
     public async Task Visit_LatestPackageRequest_returns_error_when_there_are_no_released_packages()
     {
         var packageId = "package-id";
@@ -50,7 +51,7 @@ public class ResolvePackageVersionPolicyVisitorTests
 
         var nugetRepository = SetupRepository(packageId, versions);
 
-        var sut = new ResolvePackageVersionPolicyVisitor(packageId, nugetRepository);
+        var sut = CreateVisitor(packageId, nugetRepository);
 
         var latestVersion = await sut.Visit(new LatestPackageVersionPolicy());
 
@@ -58,7 +59,7 @@ public class ResolvePackageVersionPolicyVisitorTests
         latestVersion.Error.Should().Be("Package package-id has no released versions");
     }
 
-    [Test]
+    [Test, CancelAfter(60_000)]
     public async Task Visit_LatestPackageRequest_returns_error_when_package_not_found()
     {
         var packageId = "package-id";
@@ -66,7 +67,7 @@ public class ResolvePackageVersionPolicyVisitorTests
 
         var nugetRepository = SetupRepository(packageId, versions);
 
-        var sut = new ResolvePackageVersionPolicyVisitor(packageId, nugetRepository);
+        var sut = CreateVisitor(packageId, nugetRepository);
 
         var latestVersion = await sut.Visit(new LatestPackageVersionPolicy());
 
@@ -74,7 +75,156 @@ public class ResolvePackageVersionPolicyVisitorTests
         latestVersion.Error.Should().Be("error-text");
     }
 
-    private static INuGetRepository SetupRepository(string packageId, Result<IReadOnlyCollection<NuGetVersion>> versions)
+    [Test, CancelAfter(60_000)]
+    public async Task Visit_LatestPackageRequest_skips_too_new_version_and_falls_back()
+    {
+        var packageId = "package-id";
+        var now = new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero);
+        var oldDate = now - TimeSpan.FromDays(10);
+        var newDate = now - TimeSpan.FromDays(1);
+
+        var versions = Result.Success<IReadOnlyCollection<NuGetVersion>>(
+            new NuGetVersion[]
+            {
+                new(1, 0, 0),
+                new(2, 0, 0),
+            });
+
+        var nugetRepository = SetupRepository(packageId, versions, version =>
+            version == new NuGetVersion(2, 0, 0) ? newDate : oldDate);
+
+        var timeProvider = new FakeTimeProvider(now);
+        var sut = CreateVisitor(packageId, nugetRepository, TimeSpan.FromDays(7), timeProvider);
+
+        // Act
+        var result = await sut.Visit(new LatestPackageVersionPolicy());
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(new[] { new PackageIdentity(packageId, new NuGetVersion(1, 0, 0)) });
+    }
+
+    [Test, CancelAfter(60_000)]
+    public async Task Visit_LatestPackageRequest_returns_error_when_all_versions_too_new()
+    {
+        var packageId = "package-id";
+        var now = new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero);
+        var newDate = now - TimeSpan.FromDays(1);
+
+        var versions = Result.Success<IReadOnlyCollection<NuGetVersion>>(
+            new NuGetVersion[]
+            {
+                new(1, 0, 0),
+                new(2, 0, 0),
+            });
+
+        var nugetRepository = SetupRepository(packageId, versions, _ => newDate);
+
+        var timeProvider = new FakeTimeProvider(now);
+        var sut = CreateVisitor(packageId, nugetRepository, TimeSpan.FromDays(7), timeProvider);
+
+        // Act
+        var result = await sut.Visit(new LatestPackageVersionPolicy());
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("no released versions");
+    }
+
+    [Test, CancelAfter(60_000)]
+    public async Task Visit_VersionRangePackageVersionPolicy_filters_too_new_versions()
+    {
+        var packageId = "package-id";
+        var now = new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero);
+        var oldDate = now - TimeSpan.FromDays(10);
+        var newDate = now - TimeSpan.FromDays(1);
+
+        var versions = Result.Success<IReadOnlyCollection<NuGetVersion>>(
+            new NuGetVersion[]
+            {
+                new(1, 0, 0),
+                new(1, 1, 0),
+                new(1, 2, 0),
+            });
+
+        var nugetRepository = SetupRepository(packageId, versions, version =>
+            version == new NuGetVersion(1, 2, 0) ? newDate : oldDate);
+
+        var timeProvider = new FakeTimeProvider(now);
+        var versionRange = VersionRange.Parse("[1.0.0, 2.0.0)");
+        var sut = CreateVisitor(packageId, nugetRepository, TimeSpan.FromDays(7), timeProvider);
+
+        // Act
+        var result = await sut.Visit(new VersionRangePackageVersionPolicy(versionRange));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(new[]
+        {
+            new PackageIdentity(packageId, new NuGetVersion(1, 0, 0)),
+            new PackageIdentity(packageId, new NuGetVersion(1, 1, 0)),
+        });
+    }
+
+    [Test, CancelAfter(60_000)]
+    public async Task Visit_ExactPackageVersionPolicy_ignores_release_age_filter()
+    {
+        var packageId = "package-id";
+        var now = new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero);
+        var newDate = now - TimeSpan.FromDays(1);
+        var version = new NuGetVersion(1, 0, 0);
+
+        var nugetRepository = SetupRepository(packageId,
+            Result.Success<IReadOnlyCollection<NuGetVersion>>(new[] { version }),
+            _ => newDate);
+
+        var timeProvider = new FakeTimeProvider(now);
+        var sut = CreateVisitor(packageId, nugetRepository, TimeSpan.FromDays(7), timeProvider);
+
+        // Act
+        var result = await sut.Visit(new ExactPackageVersionPolicy(version));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(new[] { new PackageIdentity(packageId, version) });
+    }
+
+    [Test, CancelAfter(60_000)]
+    public async Task Visit_LatestPackageRequest_returns_error_when_published_date_is_null()
+    {
+        var packageId = "package-id";
+        var now = new DateTimeOffset(2025, 6, 15, 0, 0, 0, TimeSpan.Zero);
+
+        var versions = Result.Success<IReadOnlyCollection<NuGetVersion>>(
+            new NuGetVersion[] { new(1, 0, 0) });
+
+        var nugetRepository = SetupRepository(packageId, versions, _ => null);
+
+        var timeProvider = new FakeTimeProvider(now);
+        var sut = CreateVisitor(packageId, nugetRepository, TimeSpan.FromDays(7), timeProvider);
+
+        // Act
+        var result = await sut.Visit(new LatestPackageVersionPolicy());
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("no publish date");
+    }
+
+    private static ResolvePackageVersionPolicyVisitor CreateVisitor(
+        string packageId,
+        INuGetRepository repository,
+        TimeSpan? minimumReleaseAge = null,
+        TimeProvider? timeProvider = null)
+    {
+        var logger = Substitute.For<IPackageRequestResolverLogger>();
+        return new ResolvePackageVersionPolicyVisitor(packageId, repository, logger, minimumReleaseAge, timeProvider ?? TimeProvider.System);
+    }
+
+    private static INuGetRepository SetupRepository(
+        string packageId,
+        Result<IReadOnlyCollection<NuGetVersion>> versions,
+        Func<NuGetVersion, DateTimeOffset?>? publishedDateProvider = null)
     {
         var packageInfoAccessor = Substitute.For<INuGetPackageInfoAccessor>();
         packageInfoAccessor.GetAllVersions(packageId, Arg.Any<CancellationToken>()).Returns(versions);
@@ -88,6 +238,7 @@ public class ResolvePackageVersionPolicyVisitorTests
                 var metadata = Substitute.For<IPackageSearchMetadata>();
                 metadata.Identity.Returns(identity);
                 metadata.IsListed.Returns(true);
+                metadata.Published.Returns(publishedDateProvider is not null ? publishedDateProvider(version) : OldPublishDate);
 
                 packageInfoAccessor.GetPackageMetadata(identity, Arg.Any<CancellationToken>()).Returns(Result.Success(metadata));
             }

--- a/tests/Promote.NuGet.Tests/Promote/FromConfiguration/PromoteConfigurationParserTests.cs
+++ b/tests/Promote.NuGet.Tests/Promote/FromConfiguration/PromoteConfigurationParserTests.cs
@@ -130,6 +130,57 @@ public class PromoteConfigurationParserTests
     }
 
     [Test]
+    public void Parse_minimum_release_age()
+    {
+        const string input =
+            """
+            minimum-release-age: 7
+
+            packages:
+              - id: System.Globalization
+                versions: 4.3.0
+            """;
+
+        var configuration = PromoteConfigurationParser.Parse(input);
+
+        configuration.MinimumReleaseAge.Should().Be(7);
+    }
+
+    [Test]
+    public void Parse_minimum_release_age_absent()
+    {
+        const string input =
+            """
+            packages:
+              - id: System.Globalization
+                versions: 4.3.0
+            """;
+
+        var configuration = PromoteConfigurationParser.Parse(input);
+
+        configuration.MinimumReleaseAge.Should().BeNull();
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    [TestCase(-100)]
+    public void Throw_validation_error_if_minimum_release_age_is_not_positive(int age)
+    {
+        var input =
+            $"""
+             minimum-release-age: {age}
+
+             packages:
+               - id: System.Globalization
+                 versions: 4.3.0
+             """;
+
+        var action = () => PromoteConfigurationParser.Parse(input);
+
+        action.Should().Throw<ValidationException>();
+    }
+
+    [Test]
     public void Throw_validation_error_if_empty_accepted_licenses()
     {
         const string input =


### PR DESCRIPTION
## Summary
Support delayed mirroring of NuGet packages — skip packages that haven't reached a minimum age since publication.

Configurable via `minimum-release-age` (days) in `packages.yml`. Only affects non-exact versions (latest and ranges). Exact versions bypass the check.

- Top-level packages: filtered out if too new, falls back to next-oldest for `latest`
- Dependencies: best-match filtered by age, fails if no suitable version exists
- Null publish date: fails with error