### PR TITLE
Standardize project file formatting and package management rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,7 @@
       "Bash(dotnet test:*)",
       "Bash(dotnet restore:*)",
       "Bash(dotnet package search:*)",
+      "Bash(dotnet package list:*)",
 
       "Bash(git add:*)",
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 # Stop the editor from looking for .editorconfig files in the parent directories
 root = true
 
-[*.{cs,csproj,props,targets}]
+[*.cs]
 indent_style = space
 indent_size = 4
 tab_width = 4
@@ -10,13 +10,12 @@ trim_trailing_whitespace = true
 max_line_length = 160
 insert_final_newline = true
 
-[*.{json,xml,xsd,md,yml,yaml}]
+[*.{csproj,props,targets,sln,slnx,json,xml,xsd,md,yml,yaml}]
 indent_style = space
 indent_size = 2
 tab_width = 2
 charset = utf-8
 trim_trailing_whitespace = true
-max_line_length = 100
 insert_final_newline = true
 
 [*]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,11 @@ For local dev, use `dotnet test` — it builds and tests in one call:
 
 ```bash
 # All tests
-dotnet test --verbosity quiet --nologo
+dotnet test --verbosity quiet
 # One project
-dotnet test --project tests/Promote.NuGet.Commands.Tests --verbosity quiet --nologo
+dotnet test --project tests/Promote.NuGet.Commands.Tests --verbosity quiet
 # One test (MTP filter syntax)
-dotnet test --project tests/Promote.NuGet.Commands.Tests --verbosity quiet --nologo -- --filter "FullyQualifiedName~DistinctQueue"
+dotnet test --project tests/Promote.NuGet.Commands.Tests --verbosity quiet -- --filter "FullyQualifiedName~DistinctQueue"
 ```
 
 Integration tests need Docker/Podman (Testcontainers).
@@ -96,7 +96,6 @@ Promote.NuGet (CLI)                   ← Spectre.Console.Cli commands, entry po
 - Use `var` when the type is obvious.
 - Always use braces for `if`/`else`/`for`/`foreach`/`while`/`do`, even single lines.
 - Keep nesting shallow — prefer early returns and guard clauses.
-- Package versions go only in `Directory.Packages.props` (central management, transitive pinning). Never add versions in `.csproj`.
 - `.editorconfig` sets formatting (4-space indent, 160-char limit). Microsoft.CodeAnalysis.NetAnalyzers enforced.
 - GitVersion handles versioning (continuous-deployment on `main`).
 
@@ -139,3 +138,15 @@ Promote.NuGet (CLI)                   ← Spectre.Console.Cli commands, entry po
 
 - XML docs: short, focused on intent and usage. Don't repeat the signature.
 - Inline comments only when code can't convey the intent: complex logic, hidden constraints, non-obvious invariants. Delete comments that just describe the next line.
+
+## Package Management
+
+Central Package Management (CPM): versions in `Directory.Packages.props`, `.csproj` files have `<PackageReference>` without `Version`.
+Package versions go only in `Directory.Packages.props` (central management, transitive pinning). Never add versions in `.csproj`.
+
+- **Check latest version** before adding: `dotnet package search <PackageId> --exact-match`
+- **Add a package**: `dotnet package add <PackageId> --project <path>` — handles CPM automatically
+- **Update**: `dotnet package update <PackageId>` or `dotnet package list --outdated` to check
+- Never manually edit versions in `Directory.Packages.props` — use `dotnet package add` / `dotnet package update`
+- Never guess versions from memory — always verify with `dotnet package search --exact-match`
+- `dotnet package update` reformats `Directory.Packages.props` (changes indentation). After running it, revert formatting with `git checkout -- Directory.Packages.props` and apply only the version change manually.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,21 +1,23 @@
 <Project>
-    <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
-        <LangVersion>14</LangVersion>
-        <Nullable>enable</Nullable>
-        <Features>strict</Features>
-        <Deterministic>true</Deterministic>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>14</LangVersion>
+    <Nullable>enable</Nullable>
+    <Features>strict</Features>
+    <Deterministic>true</Deterministic>
 
-        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-        <NoWarn>$(NoWarn);CS1591<!-- Missing XML comment-->;</NoWarn>
-    </PropertyGroup>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <NoWarn>
+      $(NoWarn);CS1591<!-- Missing XML comment-->;
+    </NoWarn>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <Using Include="System"/>
-        <Using Include="System.Collections.Generic"/>
-        <Using Include="System.Linq"/>
-        <Using Include="System.Threading"/>
-        <Using Include="System.Threading.Tasks"/>
-    </ItemGroup>
+  <ItemGroup>
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
+  </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,36 +1,36 @@
 <Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageVersion Include="CSharpFunctionalExtensions" Version="3.7.0"/>
-        <PackageVersion Include="AwesomeAssertions" Version="9.4.0"/>
-        <PackageVersion Include="FluentValidation" Version="12.1.1"/>
-        <PackageVersion Include="Humanizer.Core" Version="3.0.10"/>
-        <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4"/>
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
-        <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2"/>
-        <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="2.2.1"/>
-        <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.1"/>
-        <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="2.2.1"/>
-        <PackageVersion Include="Microsoft.Testing.Platform" Version="2.2.1"/>
-        <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.2.1"/>
-        <PackageVersion Include="NSubstitute" Version="5.3.0"/>
-        <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17"/>
-        <PackageVersion Include="NUnit" Version="4.5.1"/>
-        <PackageVersion Include="NUnit.Analyzers" Version="4.12.0"/>
-        <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0"/>
-        <PackageVersion Include="NuGet.Protocol" Version="7.3.0"/>
-        <PackageVersion Include="Nuke.Common" Version="10.1.0"/>
-        <PackageVersion Include="Spectre.Console" Version="0.55.0"/>
-        <PackageVersion Include="Spectre.Console.Analyzer" Version="1.0.0"/>
-        <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0"/>
-        <PackageVersion Include="System.Formats.Asn1" Version="10.0.5"/>
-        <PackageVersion Include="Testcontainers" Version="4.11.0"/>
-        <PackageVersion Include="YamlDotNet" Version="16.3.0"/>
-    </ItemGroup>
-    <ItemGroup>
-        <GlobalPackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201"/>
-    </ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="CSharpFunctionalExtensions" Version="3.7.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageVersion Include="FluentValidation" Version="12.1.1" />
+    <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="2.2.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="2.2.1" />
+    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.2.1" />
+    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.2.1" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
+    <PackageVersion Include="NUnit" Version="4.5.1" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.3.0" />
+    <PackageVersion Include="Nuke.Common" Version="10.1.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.55.0" />
+    <PackageVersion Include="Spectre.Console.Analyzer" Version="1.0.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
+    <PackageVersion Include="System.Formats.Asn1" Version="10.0.5" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201" />
+  </ItemGroup>
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net10.0</TargetFramework>
-        <RootNamespace></RootNamespace>
-        <NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
-        <NukeRootDirectory>..</NukeRootDirectory>
-        <NukeScriptDirectory>..</NukeScriptDirectory>
-        <NukeTelemetryVersion>1</NukeTelemetryVersion>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace></RootNamespace>
+    <NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
+    <NukeRootDirectory>..</NukeRootDirectory>
+    <NukeScriptDirectory>..</NukeScriptDirectory>
+    <NukeTelemetryVersion>1</NukeTelemetryVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Nuke.Common"/>
-        <PackageDownload Include="GitVersion.Tool" Version="[6.7.0]"/>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Nuke.Common" />
+    <PackageDownload Include="GitVersion.Tool" Version="[6.7.0]" />
+  </ItemGroup>
 
 </Project>

--- a/src/Promote.NuGet.Commands/Promote.NuGet.Commands.csproj
+++ b/src/Promote.NuGet.Commands/Promote.NuGet.Commands.csproj
@@ -1,13 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup>
-        <PackageReference Include="Humanizer.Core" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\Promote.NuGet.Feeds\Promote.NuGet.Feeds.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-            <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
-        </AssemblyAttribute>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Humanizer.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Promote.NuGet.Feeds\Promote.NuGet.Feeds.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="$(MSBuildProjectName).Tests" />
+  </ItemGroup>
 </Project>

--- a/src/Promote.NuGet.Feeds/Promote.NuGet.Feeds.csproj
+++ b/src/Promote.NuGet.Feeds/Promote.NuGet.Feeds.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup>
-        <PackageReference Include="CSharpFunctionalExtensions"/>
-        <PackageReference Include="JetBrains.Annotations"/>
-        <PackageReference Include="NuGet.Protocol"/>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CSharpFunctionalExtensions" />
+    <PackageReference Include="JetBrains.Annotations" />
+    <PackageReference Include="NuGet.Protocol" />
+  </ItemGroup>
 </Project>

--- a/src/Promote.NuGet/Promote.NuGet.csproj
+++ b/src/Promote.NuGet/Promote.NuGet.csproj
@@ -1,48 +1,45 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <PackAsTool>true</PackAsTool>
-        <ToolCommandName>promote-nuget</ToolCommandName>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>promote-nuget</ToolCommandName>
+  </PropertyGroup>
 
-    <!-- Package Metadata -->
-    <PropertyGroup>
-        <Description>A tool to promote NuGet packages and their dependencies from one feed to another.</Description>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageProjectUrl>https://github.com/Inok/NuGet.Promoter</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/Inok/NuGet.Promoter</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
-        <Authors>Pavel Borisov</Authors>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-    </PropertyGroup>
+  <!-- Package Metadata -->
+  <PropertyGroup>
+    <Description>A tool to promote NuGet packages and their dependencies from one feed to another.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Inok/NuGet.Promoter</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Inok/NuGet.Promoter</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <Authors>Pavel Borisov</Authors>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="FluentValidation" />
-        <PackageReference Include="Humanizer.Core"/>
-        <PackageReference Include="JetBrains.Annotations"/>
-        <PackageReference Include="NuGet.Protocol"/>
-        <PackageReference Include="Spectre.Console"/>
-        <PackageReference Include="Spectre.Console.Analyzer">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Spectre.Console.Cli"/>
-        <PackageReference Include="YamlDotNet" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" />
+    <PackageReference Include="Humanizer.Core" />
+    <PackageReference Include="JetBrains.Annotations" />
+    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="Spectre.Console" />
+    <PackageReference Include="Spectre.Console.Analyzer">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Spectre.Console.Cli" />
+    <PackageReference Include="YamlDotNet" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Promote.NuGet.Commands\Promote.NuGet.Commands.csproj"/>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Promote.NuGet.Commands\Promote.NuGet.Commands.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-            <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
-        </AssemblyAttribute>
-    </ItemGroup>
-    
-    <ItemGroup>
-        <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
-    </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="$(MSBuildProjectName).Tests" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,30 +1,30 @@
 <Project>
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
-    <PropertyGroup>
-        <IsPackable>false</IsPackable>
-        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
 
-        <OutputType>Exe</OutputType>
-        <EnableNUnitRunner>true</EnableNUnitRunner>
-    </PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableNUnitRunner>true</EnableNUnitRunner>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="AwesomeAssertions" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
-        <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
-        <PackageReference Include="NSubstitute" />
-        <PackageReference Include="NSubstitute.Analyzers.CSharp" />
-        <PackageReference Include="NUnit" />
-        <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="NUnit.Analyzers" />
-        <PackageReference Include="Testcontainers" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="Testcontainers" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <Using Include="NUnit.Framework"/>
-        <Using Include="NSubstitute"/>
-        <Using Include="AwesomeAssertions"/>
-    </ItemGroup>
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+    <Using Include="NSubstitute" />
+    <Using Include="AwesomeAssertions" />
+  </ItemGroup>
 </Project>

--- a/tests/Promote.NuGet.Commands.Tests/Promote.NuGet.Commands.Tests.csproj
+++ b/tests/Promote.NuGet.Commands.Tests/Promote.NuGet.Commands.Tests.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Promote.NuGet.Commands\Promote.NuGet.Commands.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NuGet.Protocol" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Promote.NuGet.Commands\Promote.NuGet.Commands.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/Promote.NuGet.Feeds.Tests/Promote.NuGet.Feeds.Tests.csproj
+++ b/tests/Promote.NuGet.Feeds.Tests/Promote.NuGet.Feeds.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Promote.NuGet.Feeds\Promote.NuGet.Feeds.csproj" />
-        <ProjectReference Include="..\Promote.NuGet.TestInfrastructure\Promote.NuGet.TestInfrastructure.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Promote.NuGet.Feeds\Promote.NuGet.Feeds.csproj" />
+    <ProjectReference Include="..\Promote.NuGet.TestInfrastructure\Promote.NuGet.TestInfrastructure.csproj" />
+  </ItemGroup>
 </Project>

--- a/tests/Promote.NuGet.TestInfrastructure/Promote.NuGet.TestInfrastructure.csproj
+++ b/tests/Promote.NuGet.TestInfrastructure/Promote.NuGet.TestInfrastructure.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <OutputType>Library</OutputType>
-        <IsTestProject>false</IsTestProject>
-        <EnableNUnitRunner>false</EnableNUnitRunner>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="NuGet.Protocol" />
-    </ItemGroup>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <IsTestProject>false</IsTestProject>
+    <EnableNUnitRunner>false</EnableNUnitRunner>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NuGet.Protocol" />
+  </ItemGroup>
 </Project>

--- a/tests/Promote.NuGet.Tests/Promote.NuGet.Tests.csproj
+++ b/tests/Promote.NuGet.Tests/Promote.NuGet.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\Promote.NuGet\Promote.NuGet.csproj" />
-        <ProjectReference Include="..\Promote.NuGet.TestInfrastructure\Promote.NuGet.TestInfrastructure.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Promote.NuGet\Promote.NuGet.csproj" />
+    <ProjectReference Include="..\Promote.NuGet.TestInfrastructure\Promote.NuGet.TestInfrastructure.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Switch project files (csproj, props, targets, slnx) to 2-space indent to match SDK tooling output
- Merge editorconfig rules for XML-like files into a single section
- Replace verbose `AssemblyAttribute` with `InternalsVisibleTo` MSBuild item
- Add package management guidelines to AGENTS.md (use `dotnet package` CLI, never guess versions)
- Whitelist `dotnet package list` in Claude config